### PR TITLE
Fix Heading Spacing

### DIFF
--- a/src/frontend-scripts/components/menu/Menu.jsx
+++ b/src/frontend-scripts/components/menu/Menu.jsx
@@ -231,7 +231,7 @@ class Menu extends React.Component {
 							|{' '}
 							<a target="_blank" href="https://discord.gg/secrethitlerio">
 								Discord
-							</a>
+							</a>{' '}
 							|{' '}
 							<a target="_blank" href="/polls" style={{ color: 'yellow' }}>
 								New Poll


### PR DESCRIPTION
Fix Discord heading spacing "Discord| New Poll" to: "Discord | New Poll" on /game top center green bar.