### PR TITLE
Minor fixes to userList sending

### DIFF
--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -97,6 +97,12 @@ module.exports = () => {
 		const { passport } = socket.handshake.session;
 		const authenticated = ensureAuthenticated(socket);
 
+		//Instantly sends the userlist as soon as the websocket is created.
+		//For some reason, sending the userlist before this happens actually doesn't work on the client. The event gets in, but is not used.
+		socket.conn.on('upgrade', () => {
+			sendUserList(socket);
+		});
+
 		socket
 			// user-events
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -219,12 +219,14 @@ const playerLeavePretourny = (game, playerName) => {
 const handleSocketDisconnect = socket => {
 	const { passport } = socket.handshake.session;
 
+	var listUpdate = false;
 	if (passport && Object.keys(passport).length) {
 		const userIndex = userList.findIndex(user => user.userName === passport.user);
 		const gamesPlayerSeatedIn = games.filter(game => game.publicPlayersState.find(player => player.userName === passport.user && !player.leftGame));
 
 		if (userIndex !== -1) {
 			userList.splice(userIndex, 1);
+			listUpdate = true;
 		}
 
 		if (gamesPlayerSeatedIn.length) {
@@ -251,6 +253,7 @@ const handleSocketDisconnect = socket => {
 				}
 			});
 			sendGameList();
+			listUpdate = true;
 		} else {
 			const tournysPlayerQueuedIn = games.filter(
 				game =>
@@ -264,7 +267,7 @@ const handleSocketDisconnect = socket => {
 			});
 		}
 	}
-	sendUserList();
+	if (listUpdate) sendUserList();
 };
 
 const crashReport = JSON.stringify({
@@ -1935,11 +1938,11 @@ module.exports.checkUserStatus = socket => {
 			socket.emit('updateSeatForUser');
 			sendInProgressGameUpdate(game);
 		}
+		if (user) sendUserList();
 	}
 
 	socket.emit('version', { current: version });
 
-	sendUserList();
 	sendGeneralChats(socket);
 	sendGameList(socket);
 };

--- a/routes/socket/user-requests.js
+++ b/routes/socket/user-requests.js
@@ -12,7 +12,8 @@ const {
 	ipbansNotEnforced,
 	gameCreationDisabled,
 	currentSeasonNumber,
-	userListEmitter
+	userListEmitter,
+	formattedUserList
 } = require('./models');
 const { getProfile } = require('../../models/profile/utils');
 const { sendInProgressGameUpdate } = require('./util');
@@ -140,8 +141,6 @@ module.exports.sendUserGameSettings = socket => {
 				current: version,
 				lastSeen: account.lastVersionSeen || 'none'
 			});
-
-			userListEmitter.send = true;
 		})
 		.catch(err => {
 			console.log(err);


### PR DESCRIPTION
List is no longer sent whenever a client that is not logged in opens or closes the page.
List is instantly send to new clients, even if they are about to get the list from a global update due to them logging in.